### PR TITLE
Fix docs deploy error due to missing extensions. #patch

### DIFF
--- a/.github/workflows/prod-docs.yml
+++ b/.github/workflows/prod-docs.yml
@@ -19,3 +19,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: docs/mkdocs.yml
           EXTRA_PACKAGES: build-base
+          REQUIREMENTS: requirements-dev.txt


### PR DESCRIPTION
- [Fix docs deploy error due to missing extensions. #patch](https://github.com/vanalmsick/news_platform/commit/8c74f5bb84bfbb23b3d7bc619e5602664cbe940e)